### PR TITLE
Fix email address regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .classpath
 .DS_Store
 .project
+/.idea
+*.iml

--- a/src/main/java/de/tschumacher/utils/validation/EmailValidator.java
+++ b/src/main/java/de/tschumacher/utils/validation/EmailValidator.java
@@ -21,9 +21,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class EmailValidator {
-
-	private static final String EMAIL_PATTERN = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
-			+ "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
+	// https://howtodoinjava.com/regex/java-regex-validate-email-address/
+	private static final String EMAIL_PATTERN = "^[a-zA-Z0-9_!#$%&’*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$";
 
 	public static boolean validate(final String hex) {
 

--- a/src/test/java/de/tschumacher/utils/validation/EmailValidatorTest.java
+++ b/src/test/java/de/tschumacher/utils/validation/EmailValidatorTest.java
@@ -1,0 +1,48 @@
+package de.tschumacher.utils.validation;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EmailValidatorTest {
+
+    @Test
+    public void shouldReturnFalseForStringsWithoutDomain() {
+        String emailAddress = "tobias";
+
+        boolean valid = EmailValidator.validate(emailAddress);
+        Assert.assertFalse(valid);
+    }
+
+    @Test
+    public void shouldReturnFalseForStringsWithJustDomain() {
+        String emailAddress = "@gmail.com";
+
+        boolean valid = EmailValidator.validate(emailAddress);
+        Assert.assertFalse(valid);
+    }
+
+    @Test
+    public void shouldReturnTrueForSimpleDomain() {
+        String emailAddress = "tobias@schumacher.de";
+
+        boolean valid = EmailValidator.validate(emailAddress);
+        Assert.assertTrue(valid);
+    }
+
+    @Test
+    public void shouldReturnTrueForComplexDomain() {
+        String emailAddress = "Tobias@test.test-test.de";
+
+        boolean valid = EmailValidator.validate(emailAddress);
+        Assert.assertTrue(valid);
+    }
+
+    @Test
+    public void shouldReturnTrueForEmailAddressWithPluSign() {
+        String emailAddress = "Tobias+test@schumacher.de";
+
+        boolean valid = EmailValidator.validate(emailAddress);
+        Assert.assertTrue(valid);
+    }
+
+}


### PR DESCRIPTION
Email addresses such as “Tobias@test.test-test.de” were marked as invalid although they aren’t.